### PR TITLE
document `read:user` scope is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ contributions.
 The token permissions should include the following:
 
 - Read access to repositories, issues, and pull requests
+- Read access to your user profile (`read:user`)
 - Write access to issues
 - (Optional) Write access to projects
 


### PR DESCRIPTION
Only public contributions will be returned unless the `read:user` scope is enabled